### PR TITLE
Stringsasfactors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-
-language: R
+language: r
 sudo: false
 cache: packages
+r:
+  - oldrel
+  - release
+  - devel

--- a/R/centroid.R
+++ b/R/centroid.R
@@ -185,7 +185,7 @@ dist_multi_centroids <- function (d, g, squared = FALSE) {
     idx2 <- group_idxs[[g2]]
     dist_between_centroids(d, idx1, idx2, squared = squared)
   }
-  dc <- combn(names(group_idxs), 2, centroid_distance_from_groups)
+  dc <- utils::combn(names(group_idxs), 2, centroid_distance_from_groups)
   attr(dc, "Size") <- length(names(group_idxs))
   attr(dc, "Labels") <- names(group_idxs)
   attr(dc, "Diag") <- FALSE

--- a/R/dist.R
+++ b/R/dist.R
@@ -128,7 +128,8 @@ dist_groups <- function(d, g) {
       level1 == level2,
       paste("Within", level1),
       paste("Between", level1, "and", level2))),
-    Distance = dist_get(d, idx1, idx2))
+    Distance = dist_get(d, idx1, idx2),
+    stringsAsFactors = FALSE)
 }
 
 #' Make a distance matrix using a custom distance function

--- a/R/dist.R
+++ b/R/dist.R
@@ -124,10 +124,10 @@ dist_groups <- function(d, g) {
     Item2 = if (is.null(dlabels)) idx2 else dlabels[idx2],
     Group1 = g[idx1],
     Group2 = g[idx2],
-    Label = ifelse(
+    Label = factor(ifelse(
       level1 == level2,
       paste("Within", level1),
-      paste("Between", level1, "and", level2)),
+      paste("Between", level1, "and", level2))),
     Distance = dist_get(d, idx1, idx2))
 }
 


### PR DESCRIPTION
In the development version of R, the default value for `stringsAsFactors` is set to `FALSE` for the `data.frame()` function. This caused an error because the tests were expecting a character vector to be converted to a factor.

In response, we (1) explicitly cast the character vector to a factor, (2) manually set `stringsAsFactors = FALSE` to ensure compatibility, and (3) updated the Travis config to test against the latest development version of R.